### PR TITLE
Use standard SPDX identifier for license

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "email": "mike.diarmid@gmail.com",
     "url": "http://github.com/Salakar/"
   },
-  "license": "APACHE-2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Salakar/cluster-key-slot/issues"
   },


### PR DESCRIPTION
Various automatic tools do exact checks against strings listed here https://spdx.org/licenses/

cluster-key-slot uses upper-case name which isn't properly matched